### PR TITLE
[PG-3] Add Codacy badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
+ 
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/bfabada245a447199e69de8a2953c3d7)](https://app.codacy.com/gh/namely/netsuite-gem-fork/dashboard)
+[![Codacy Badge](https://app.codacy.com/project/badge/Coverage/bfabada245a447199e69de8a2953c3d7)](https://app.codacy.com/gh/namely/netsuite-gem-fork/dashboard)
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 


### PR DESCRIPTION

# What does this do?

This PR adds the Codacy badges to the README.md

# Why are we doing this?

The Codacy badges provide an easy at-a-glance view of the code quality and coverage for the repository and increase awareness of quality goals.

Please drop in on the #codacy-discussion channel in Slack if you have any questions.